### PR TITLE
Update printInfo() and setupClipboard()

### DIFF
--- a/limoji
+++ b/limoji
@@ -110,7 +110,7 @@ invalidArgument() {
 setupClipboard() {
     case "${XDG_SESSION_TYPE}" in
         (x11)
-            # If x11 and xclip are simultaneously present, that's a preferred option
+            # If X11 and xclip are simultaneously present, that's a preferred option
             if command -v xclip >/dev/null 2>&1; then
                 copyToClipboard() { xclip -selection c; }
                 return 0
@@ -121,7 +121,7 @@ setupClipboard() {
             fi
         ;;
         (wayland)
-            # if wayland and wl-copy are simultaneously present, that's a preferred option
+            # if Wayland and wl-copy are simultaneously present, that's a preferred option
             if command -v wl-copy >/dev/null 2>&1; then
                 copyToClipboard() { wl-copy; }
                 return 0

--- a/limoji
+++ b/limoji
@@ -121,7 +121,7 @@ setupClipboard() {
             fi
         ;;
         (wayland)
-            # if Wayland and wl-copy are simultaneously present, that's a preferred option
+            # If Wayland and wl-copy are simultaneously present, that's a preferred option
             if command -v wl-copy >/dev/null 2>&1; then
                 copyToClipboard() { wl-copy; }
                 return 0

--- a/limoji
+++ b/limoji
@@ -10,7 +10,7 @@ printCross() {
 }
 
 printInfo() {
-    printf -- '[\e[1;93mi\e[0m] %b' "${*}"
+    printf -- '[\e[1;93mi\e[0m] %b\n' "${*}"
 }
 
 printQuestion() {
@@ -52,7 +52,7 @@ printCmdInfo() {
     all done using the terminal!
 
     All you have to do is pick the right one or let Limoji choose it for you!
-    \n"
+    "
 }
 
 # Print Limoji's version
@@ -108,37 +108,51 @@ invalidArgument() {
 
 # Attempt to figure out a clipboard handling method
 setupClipboard() {
-    # If X11 and xclip are simultaneously present, that's a preferred option
-    if [[ "${XDG_SESSION_TYPE}" = "x11" ]]; then
-        # Verify xclip has been installed
-        if command -v xclip >/dev/null 2>&1; then
-            copyToClipboard() { xclip -selection c; }
-            return 0
-        else
-            printInfo 'X11 detected\n'
-            printCross 'xclip is required for copying text to the clipboard'
-            exit 2
-        fi
-    elif [[ "${XDG_SESSION_TYPE}" = "wayland" ]]; then
-        # wl-copy is preferred when using Wayland
-        if command -v wl-copy >/dev/null 2>&1; then
-            copyToClipboard() { wl-copy; }
-            return 0
-        # Fallback if wl-copy isn't installed
-        elif command -v xclip >/dev/null 2>&1; then
-            copyToClipboard() { xclip -selection c; }
-            return 0
-        else
-            printInfo 'Wayland detected\n'
-            printCross 'wl-clipboard is required for copying text to the clipboard'
-            exit 2
-        fi
-    # If we get to this point, then it only means that XDG_SESSION_TYPE isn't set
-    else
-        printCross "Your system is not supported yet, please create a new issue here:"
-        printf -- '%s\n' "https://github.com/GEROGIANNIS/Limoji/issues/new/choose" >&2
-        exit 1
-    fi
+    case "${XDG_SESSION_TYPE}" in
+        (x11)
+            # If x11 and xclip are simultaneously present, that's a preferred option
+            if command -v xclip >/dev/null 2>&1; then
+                copyToClipboard() { xclip -selection c; }
+                return 0
+            else
+                printInfo 'X11 detected'
+                printCross 'xclip is required for copying text to the clipboard'
+                exit 1
+            fi
+        ;;
+        (wayland)
+            # if wayland and wl-copy are simultaneously present, that's a preferred option
+            if command -v wl-copy >/dev/null 2>&1; then
+                copyToClipboard() { wl-copy; }
+                return 0
+            else
+                printInfo 'Wayland detected'
+                printCross 'wl-clipboard is required for copying text to the clipboard'
+                exit 1
+            fi
+        ;;
+        (*)
+            # If we get to this point, then it only means that XDG_SESSION_TYPE isn't set
+            # We can run some more thorough heuristics to try and find a way to clipboard things
+            if command -v wl-copy >/dev/null 2>&1; then
+                copyToClipboard() { wl-copy; }
+                return 0
+            elif command -v xclip >/dev/null 2>&1; then
+                copyToClipboard() { xclip -selection c; }
+                return 0
+            elif command -v xsel >/dev/null 2>&1; then
+                copyToClipboard() { xsel --clipboard --input; }
+                return 0
+            elif command -v pbcopy >/dev/null 2>&1; then
+                copyToClipboard() { pbcopy; }
+                return 0
+            else
+                printCross "Your system is not supported yet, please create a new issue here:"
+                printf -- '%s\n' "https://github.com/GEROGIANNIS/Limoji/issues/new/choose" >&2
+                exit 1
+            fi
+        ;;
+    esac
 }
 
 main() {

--- a/limoji
+++ b/limoji
@@ -125,6 +125,10 @@ setupClipboard() {
             if command -v wl-copy >/dev/null 2>&1; then
                 copyToClipboard() { wl-copy; }
                 return 0
+            # Fallback if wl-copy isn't installed
+            elif command -v xclip >/dev/null 2>&1; then
+                copyToClipboard() { xclip -selection c; }
+                return 0
             else
                 printInfo 'Wayland detected'
                 printCross 'wl-clipboard is required for copying text to the clipboard'


### PR DESCRIPTION
In response to a comment on #18.  This approach should cover a wider range of environments including WSL2 and Mac, where `XDG_SESSION_TYPE` is not used.  Mac, specifically, is addressed by `pbcopy`, but this will need testing as I don't have a Macbook handy.